### PR TITLE
Fix ReferenceError: json is not defined

### DIFF
--- a/tasks/serum.coffee
+++ b/tasks/serum.coffee
@@ -82,7 +82,7 @@ gulp.task "#{$.prefix}-generate-meta", ->
           author: row.Author?.trim()
     .pipe tap (file) ->
       file.data.uuid = util.uuid file
-      file.contents = Buffer.from json util.beautify file.data, on
+      file.contents = Buffer.from util.beautify file.data, on
     .pipe rename
       extname: '.meta'
     .pipe gulp.dest "src/#{$.dir}/presets"


### PR DESCRIPTION
I couldn't run `gulp serum-generate-meta` because of this error.
Apparently we don't need any data parsing there, it works perfectly without that `json` function 😉 